### PR TITLE
Spike: evaluate page.addLocatorHandler for ad handling

### DIFF
--- a/tests/e2e/Brand_products.spec.ts
+++ b/tests/e2e/Brand_products.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { ProductsPage } from '../../pages/productsPage';
 import { apiHelper } from '../../utils/apiHelper';
 

--- a/tests/e2e/Cart_add_products.spec.ts
+++ b/tests/e2e/Cart_add_products.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { ProductsPage } from '../../pages/productsPage';
 import { CartPage } from '../../pages/cartPage';
 

--- a/tests/e2e/Cart_product_quantity.spec.ts
+++ b/tests/e2e/Cart_product_quantity.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { ProductDetailsPage } from '../../pages/productDetailsPage';
 import { CartPage } from '../../pages/cartPage';
 

--- a/tests/e2e/Cart_remove_products.spec.ts
+++ b/tests/e2e/Cart_remove_products.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { HomePage } from '../../pages/homePage';
 import { CartPage } from '../../pages/cartPage';
 

--- a/tests/e2e/Cart_search_persistence.spec.ts
+++ b/tests/e2e/Cart_search_persistence.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { ProductsPage } from '../../pages/productsPage';
 import { CartPage } from '../../pages/cartPage';
 import { LoginPage } from '../../pages/loginPage';

--- a/tests/e2e/Category_products.spec.ts
+++ b/tests/e2e/Category_products.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { HomePage } from '../../pages/homePage';
 import { apiHelper } from '../../utils/apiHelper';
 

--- a/tests/e2e/Product_review.spec.ts
+++ b/tests/e2e/Product_review.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { ProductsPage } from '../../pages/productsPage';
 import { ProductDetailsPage } from '../../pages/productDetailsPage';
 

--- a/tests/e2e/Products_details.spec.ts
+++ b/tests/e2e/Products_details.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { HomePage } from '../../pages/homePage';
 import { ProductsPage } from '../../pages/productsPage';
 import { ProductDetailsPage } from '../../pages/productDetailsPage';

--- a/tests/e2e/Products_search.spec.ts
+++ b/tests/e2e/Products_search.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { ProductsPage } from '../../pages/productsPage';
 
 test('E2E-9: Search Product @high', async ({ page }, testInfo) => {

--- a/utils/adHandlers.ts
+++ b/utils/adHandlers.ts
@@ -1,0 +1,34 @@
+import { Locator, Page } from '@playwright/test';
+
+async function clickIfVisible(locator: Locator) {
+  if (await locator.isVisible().catch(() => false)) {
+    await locator.click().catch(() => {});
+  }
+}
+
+export async function registerCommonAdHandlers(page: Page) {
+  const consentButton = page.getByRole('button', { name: /consent|accept/i }).last();
+  const adCloseButton = page.locator('div.GoogleActiveViewElement div[aria-label="Close ad"]');
+  const promoCloseButton = page.locator('div#ad_position_box div#dismiss-button');
+  const genericCloseButton = page
+    .getByRole('button', { name: /close/i })
+    .or(page.getByRole('link', { name: /close/i }))
+    .or(page.getByText(/close/i))
+    .last();
+
+  await page.addLocatorHandler(consentButton, async locator => {
+    await clickIfVisible(locator);
+  });
+
+  await page.addLocatorHandler(adCloseButton, async locator => {
+    await clickIfVisible(locator);
+  });
+
+  await page.addLocatorHandler(promoCloseButton, async locator => {
+    await clickIfVisible(locator);
+  });
+
+  await page.addLocatorHandler(genericCloseButton, async locator => {
+    await clickIfVisible(locator);
+  });
+}

--- a/utils/fixtures.ts
+++ b/utils/fixtures.ts
@@ -1,5 +1,6 @@
 import { test as base } from '@playwright/test';
 import { User } from '../data/user';
+import { registerCommonAdHandlers } from './adHandlers';
 import { apiHelper } from './apiHelper';
 
 type CreatedUserCleanup = {
@@ -12,6 +13,11 @@ type Fixtures = {
 };
 
 export const test = base.extend<Fixtures>({
+  page: async ({ page }, use) => {
+    await registerCommonAdHandlers(page);
+    await use(page);
+  },
+
   managedUser: async ({ request }, use, testInfo) => {
     const user = await apiHelper.createManagedUser(request, testInfo);
     await use(user);


### PR DESCRIPTION
## Summary
This draft PR preserves an experiment with `page.addLocatorHandler()` for handling aggressive ads and overlays in E2E tests.

## Goal
Evaluate whether global locator handlers can replace the current explicit ad-handling approach.

## Result
The experiment did not improve stability.
In some cases it made behavior less predictable, especially in Firefox and WebKit.

## Conclusion
This branch is kept for reference only and is **not intended to be merged**.

Related issue: #[12](https://github.com/obutkalyuk/pw-e2e-automationexercise/issues/12)
