### PR TITLE
Mitigate third-party ad and consent interference in Playwright UI tests

### DIFF
--- a/pages/basePage.ts
+++ b/pages/basePage.ts
@@ -40,19 +40,9 @@ export class BasePage {
     }
 
     async handleCommonAds() {
-        const adCloseButton = this.page.locator('div.GoogleActiveViewElement div[aria-label="Close ad"]');
-        const promoCloseButton = this.page.locator('div#ad_position_box div#dismiss-button');
-        const iframeCloseButton = this.page.locator('iframe[name="ad_iframe"]').contentFrame().getByRole('button', { name: 'Close ad' });
-        const consentButton = this.page.getByRole('button', { name: 'Consent' });
-        const genericCloseButton = this.page
-            .getByRole('button', { name: /^close$/i })
-            .or(this.page.getByRole('link', { name: /^close$/i }))
-            .first();
-        await this.clickIfPresent(consentButton);
-        await this.clickIfPresent(adCloseButton);
-        await this.clickIfPresent(promoCloseButton);
-        await this.clickIfPresent(iframeCloseButton);
-        await this.clickIfPresent(genericCloseButton);
+        // Third-party ad traffic is now blocked at the network layer in the shared fixture.
+        // Keep this method as a no-op for now so existing page-object calls stay intact
+        // while we validate that the old click-based ad handling is no longer needed.
     }
 
     protected async handleAdsIfNeeded(adHandler?: () => Promise<void>) {

--- a/scripts/ad-traffic-spike.ts
+++ b/scripts/ad-traffic-spike.ts
@@ -21,7 +21,7 @@ import { CartPage } from '../pages/cartPage';
 dotenv.config({ path: path.resolve(process.cwd(), '.env') });
 
 type BrowserName = 'chromium' | 'firefox' | 'webkit';
-type RunMode = 'standard' | 'baseline';
+type RunMode = 'standard' | 'baseline' | 'targeted-ad-block';
 type FlowName =
   | 'products-details'
   | 'brand-products'
@@ -142,6 +142,25 @@ const FIRST_PARTY_HOSTS = new Set([
   'www.automationexercise.com',
 ]);
 
+const AD_DOMAINS_PRIMARY = [
+  'pagead2.googlesyndication.com',
+  'tpc.googlesyndication.com',
+  'googleads.g.doubleclick.net',
+  'googleads4.g.doubleclick.net',
+  'ep1.adtrafficquality.google',
+  'ep2.adtrafficquality.google',
+] as const;
+
+const AD_DOMAINS_SECONDARY = [
+  'cm.g.doubleclick.net',
+  's0.2mdn.net',
+] as const;
+
+const TARGETED_AD_BLOCK_HOSTS: ReadonlySet<string> = new Set([
+  ...AD_DOMAINS_PRIMARY,
+  ...AD_DOMAINS_SECONDARY,
+]);
+
 function getArgValue(name: string): string | undefined {
   const flag = `--${name}`;
   const withEqualsPrefix = `${flag}=`;
@@ -211,7 +230,10 @@ function parseOptions(): CliOptions {
     headed: hasFlag('headed'),
     slowMo,
     browsers: parseCsvList(getArgValue('browsers'), ['chromium', 'firefox', 'webkit'] as const),
-    modes: parseCsvList(getArgValue('modes'), ['standard', 'baseline'] as const),
+    modes: parseCsvList(
+      getArgValue('modes'),
+      ['standard', 'baseline', 'targeted-ad-block'] as const
+    ),
     flows: parseCsvList(getArgValue('flows'), FLOW_NAMES),
     outputRoot,
   };
@@ -610,6 +632,31 @@ async function applyBaselineRouting(context: BrowserContext): Promise<void> {
   });
 }
 
+async function applyTargetedAdBlockRouting(context: BrowserContext): Promise<void> {
+  await context.route('**/*', async (route) => {
+    const requestUrl = route.request().url();
+    let parsedUrl: URL | null = null;
+
+    try {
+      parsedUrl = new URL(requestUrl);
+    } catch {
+      parsedUrl = null;
+    }
+
+    if (!parsedUrl || !['http:', 'https:'].includes(parsedUrl.protocol)) {
+      await route.continue();
+      return;
+    }
+
+    if (TARGETED_AD_BLOCK_HOSTS.has(parsedUrl.hostname)) {
+      await route.abort();
+      return;
+    }
+
+    await route.continue();
+  });
+}
+
 async function runProductsDetailsFlow(page: Page): Promise<void> {
   const homePage = new HomePage(page);
   const productsPage = new ProductsPage(page);
@@ -725,6 +772,8 @@ async function executeRun(
 
   if (mode === 'baseline') {
     await applyBaselineRouting(context);
+  } else if (mode === 'targeted-ad-block') {
+    await applyTargetedAdBlockRouting(context);
   }
 
   const page = await context.newPage();
@@ -1062,6 +1111,7 @@ function buildMarkdownReport(
     '## Notes',
     '',
     '- `baseline` mode aborts every third-party HTTP(S) request to establish a clean reference profile.',
+    `- \`targeted-ad-block\` aborts only the shortlisted ad-serving hosts: ${[...TARGETED_AD_BLOCK_HOSTS].map((host) => `\`${host}\``).join(', ')}.`,
     '- Initiator stacks are best-effort and are only collected in Chromium via CDP.',
     '- Each run also writes a raw `run.json` alongside `network.har` for deeper inspection.',
     '',

--- a/tests/e2e/Brand_products.spec.ts
+++ b/tests/e2e/Brand_products.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { ProductsPage } from '../../pages/productsPage';
 import { apiHelper } from '../../utils/apiHelper';
 

--- a/tests/e2e/Cart_add_products.spec.ts
+++ b/tests/e2e/Cart_add_products.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { ProductsPage } from '../../pages/productsPage';
 import { CartPage } from '../../pages/cartPage';
 

--- a/tests/e2e/Cart_product_quantity.spec.ts
+++ b/tests/e2e/Cart_product_quantity.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { ProductDetailsPage } from '../../pages/productDetailsPage';
 import { CartPage } from '../../pages/cartPage';
 

--- a/tests/e2e/Cart_remove_products.spec.ts
+++ b/tests/e2e/Cart_remove_products.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { HomePage } from '../../pages/homePage';
 import { CartPage } from '../../pages/cartPage';
 

--- a/tests/e2e/Cart_search_persistence.spec.ts
+++ b/tests/e2e/Cart_search_persistence.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { ProductsPage } from '../../pages/productsPage';
 import { CartPage } from '../../pages/cartPage';
 import { LoginPage } from '../../pages/loginPage';

--- a/tests/e2e/Category_products.spec.ts
+++ b/tests/e2e/Category_products.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { HomePage } from '../../pages/homePage';
 import { apiHelper } from '../../utils/apiHelper';
 

--- a/tests/e2e/Product_review.spec.ts
+++ b/tests/e2e/Product_review.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { ProductsPage } from '../../pages/productsPage';
 import { ProductDetailsPage } from '../../pages/productDetailsPage';
 

--- a/tests/e2e/Products_details.spec.ts
+++ b/tests/e2e/Products_details.spec.ts
@@ -1,4 +1,5 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { HomePage } from '../../pages/homePage';
 import { ProductsPage } from '../../pages/productsPage';
 import { ProductDetailsPage } from '../../pages/productDetailsPage';

--- a/tests/e2e/Products_search.spec.ts
+++ b/tests/e2e/Products_search.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test';
+import { test } from '../../utils/fixtures';
 import { ProductsPage } from '../../pages/productsPage';
 
 test('E2E-9: Search Product @high', async ({ page }, testInfo) => {

--- a/tests/monitoring/Account_create_concurrency.spec.ts
+++ b/tests/monitoring/Account_create_concurrency.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import { User } from '../../data/user';
 import { LoginPage } from '../../pages/loginPage';
 import { SignupPage } from '../../pages/signupPage';
+import { applyAdAndConsentMitigation } from '../../utils/fixtures';
 
 test('C-1 Concurrency Probe: User registration under parallel load', async ({ browser }) => {
     const taskCount = 10;
@@ -9,6 +10,7 @@ test('C-1 Concurrency Probe: User registration under parallel load', async ({ br
     const tasks = Array.from({ length: taskCount }).map(async () => {
         const context = await browser.newContext();
         const page = await context.newPage();
+        await applyAdAndConsentMitigation(context, page);
         const user = User.generateRandom();
 
         try {
@@ -32,4 +34,3 @@ test('C-1 Concurrency Probe: User registration under parallel load', async ({ br
         throw new Error(`${failed.length} users failed to register under parallel load.`);
     }
 });
-

--- a/utils/fixtures.ts
+++ b/utils/fixtures.ts
@@ -1,4 +1,4 @@
-import { test as base } from '@playwright/test';
+import { BrowserContext, Page, test as base } from '@playwright/test';
 import { User } from '../data/user';
 import { apiHelper } from './apiHelper';
 
@@ -22,30 +22,94 @@ const TARGETED_AD_BLOCK_HOSTS = new Set([
   's0.2mdn.net',
 ]);
 
+const CONSENT_NEUTRALIZATION_SCRIPT = `
+(() => {
+  const STYLE_ID = 'pw-consent-neutralizer';
+  const SELECTORS = [
+    'iframe[src*="fundingchoicesmessages.google.com"]',
+    'iframe[src*="google.com/fundingchoices"]',
+    'iframe[id*="googlefc"]',
+    'iframe[name*="googlefc"]',
+    '[id*="googlefc"]',
+    '[class*="googlefc"]',
+    '[aria-label*="consent" i]',
+    '[aria-modal="true"][role="dialog"]'
+  ];
+
+  const hideMatchingNodes = () => {
+    for (const selector of SELECTORS) {
+      for (const node of document.querySelectorAll(selector)) {
+        if (!(node instanceof HTMLElement)) continue;
+        node.style.setProperty('display', 'none', 'important');
+        node.style.setProperty('visibility', 'hidden', 'important');
+        node.style.setProperty('opacity', '0', 'important');
+        node.style.setProperty('pointer-events', 'none', 'important');
+      }
+    }
+  };
+
+  const ensureStyle = () => {
+    if (document.getElementById(STYLE_ID)) return;
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = [
+      'iframe[src*="fundingchoicesmessages.google.com"]',
+      'iframe[src*="google.com/fundingchoices"]',
+      'iframe[id*="googlefc"]',
+      'iframe[name*="googlefc"]',
+      '[id*="googlefc"]',
+      '[class*="googlefc"]',
+      '[aria-label*="consent" i]'
+    ].join(',') + '{display:none !important;visibility:hidden !important;opacity:0 !important;pointer-events:none !important;}';
+    document.documentElement.appendChild(style);
+  };
+
+  ensureStyle();
+  hideMatchingNodes();
+
+  const observer = new MutationObserver(() => {
+    ensureStyle();
+    hideMatchingNodes();
+  });
+
+  observer.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    attributes: true
+  });
+})();
+`;
+
+export async function applyAdAndConsentMitigation(context: BrowserContext, page: Page) {
+  await page.addInitScript(CONSENT_NEUTRALIZATION_SCRIPT);
+
+  await context.route('**/*', async (route) => {
+    const requestUrl = route.request().url();
+    let parsedUrl: URL | null = null;
+
+    try {
+      parsedUrl = new URL(requestUrl);
+    } catch {
+      parsedUrl = null;
+    }
+
+    if (!parsedUrl || !['http:', 'https:'].includes(parsedUrl.protocol)) {
+      await route.continue();
+      return;
+    }
+
+    if (TARGETED_AD_BLOCK_HOSTS.has(parsedUrl.hostname)) {
+      await route.abort();
+      return;
+    }
+
+    await route.continue();
+  });
+}
+
 export const test = base.extend<Fixtures>({
   page: async ({ page }, use) => {
-    await page.context().route('**/*', async (route) => {
-      const requestUrl = route.request().url();
-      let parsedUrl: URL | null = null;
-
-      try {
-        parsedUrl = new URL(requestUrl);
-      } catch {
-        parsedUrl = null;
-      }
-
-      if (!parsedUrl || !['http:', 'https:'].includes(parsedUrl.protocol)) {
-        await route.continue();
-        return;
-      }
-
-      if (TARGETED_AD_BLOCK_HOSTS.has(parsedUrl.hostname)) {
-        await route.abort();
-        return;
-      }
-
-      await route.continue();
-    });
+    await applyAdAndConsentMitigation(page.context(), page);
 
     await use(page);
   },

--- a/utils/fixtures.ts
+++ b/utils/fixtures.ts
@@ -11,7 +11,45 @@ type Fixtures = {
   createdUserCleanup: CreatedUserCleanup;
 };
 
+const TARGETED_AD_BLOCK_HOSTS = new Set([
+  'pagead2.googlesyndication.com',
+  'tpc.googlesyndication.com',
+  'googleads.g.doubleclick.net',
+  'googleads4.g.doubleclick.net',
+  'ep1.adtrafficquality.google',
+  'ep2.adtrafficquality.google',
+  'cm.g.doubleclick.net',
+  's0.2mdn.net',
+]);
+
 export const test = base.extend<Fixtures>({
+  page: async ({ page }, use) => {
+    await page.context().route('**/*', async (route) => {
+      const requestUrl = route.request().url();
+      let parsedUrl: URL | null = null;
+
+      try {
+        parsedUrl = new URL(requestUrl);
+      } catch {
+        parsedUrl = null;
+      }
+
+      if (!parsedUrl || !['http:', 'https:'].includes(parsedUrl.protocol)) {
+        await route.continue();
+        return;
+      }
+
+      if (TARGETED_AD_BLOCK_HOSTS.has(parsedUrl.hostname)) {
+        await route.abort();
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await use(page);
+  },
+
   managedUser: async ({ request }, use, testInfo) => {
     const user = await apiHelper.createManagedUser(request, testInfo);
     await use(user);


### PR DESCRIPTION
Summary
This PR introduces a targeted mitigation for third-party ad traffic and consent overlays that were causing unstable UI behavior during Playwright runs against automationexercise.com.

The mitigation is intentionally focused. It does not block all third-party traffic and does not reintroduce broad click-based ad handling. Instead, it applies a narrowed network blocklist for the ad hosts most strongly correlated with #google_vignette, overlays, and click interception, and adds lightweight consent-overlay neutralization to reduce UI obstruction and screenshot noise.

What Changed

Added targeted ad-domain blocking in the shared Playwright fixture
Added consent-overlay neutralization via init script
Reused the same mitigation for the monitoring concurrency test, which creates its own browser contexts
Disabled the old click-based ad handler path so the suite now relies on network-layer mitigation rather than reactive overlay clicking
Ad Domains Blocked

pagead2.googlesyndication.com
tpc.googlesyndication.com
googleads.g.doubleclick.net
googleads4.g.doubleclick.net
ep1.adtrafficquality.google
ep2.adtrafficquality.google
cm.g.doubleclick.net
s0.2mdn.net
Why
Previous investigation and mitigation spikes showed that the dominant flaky behavior was caused by third-party ad traffic and related overlay/interstitial behavior, especially around #google_vignette. Broad third-party blocking improved stability but was too aggressive. This PR adopts the narrower strategy that performed best during the mitigation experiment.

Observed Result
The suite is now significantly cleaner with respect to ad-related instability. The earlier overlay/vignette pattern is no longer the primary failure mode. Remaining failures are now mostly isolated to Firefox timing/actionability issues and one Chromium navigation timeout, which suggests the ad-related flakiness has largely been addressed.

Scope
This PR is intended to mitigate third-party ad and consent interference only. It does not attempt to solve the remaining Firefox-specific stability issues; those should be handled in a separate follow-up.

Follow-Up

Track remaining Firefox-specific flakiness separately
Review whether the old no-op ad handler can be fully removed in a later cleanup pass
Optionally mark the monitoring concurrency probe as expected-to-fail if that behavior remains known and intentional