### PR TITLE
Fix import-time side effects in report helper scripts

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -31,6 +31,8 @@ jobs:
         run: npm run format:check
       - name: Lint
         run: npm run lint
+      - name: Check report tool imports
+        run: npm run check:report-tools
       - name: Get Playwright version
         run: echo "PLAYWRIGHT_VERSION=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_ENV"
       - name: Cache Playwright browsers

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "archive:reports": "tsx scripts/archive-playwright-reports.ts",
+    "check:report-tools": "tsx scripts/check-report-tools.ts",
     "lint": "eslint . --ext .ts,.js",
     "lint:fix": "eslint . --ext .ts,.js --fix",
     "format": "prettier --write .",

--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,7 @@ qa_questions.md
 GitHub Actions is used for regular execution and feedback:
 
 - PR validation runs three fast checks: `changed-tests`, `smoke`, and `a11y-smoke`
+- PR validation also includes a lightweight guard for report-helper scripts so import-time side effects are caught before merge
 - `changed-tests` executes only changed spec files when relevant
 - `smoke` covers lightweight API and browser smoke scenarios for core flows
 - `a11y-smoke` is reserved for lightweight accessibility checks without duplicating full E2E coverage
@@ -158,6 +159,7 @@ Useful commands:
 
 ```bash
 npm run archive:reports
+npm run check:report-tools
 npm run parse:failures
 npm run parse:failures:dir -- <directory>
 ```
@@ -173,6 +175,7 @@ What these commands do:
 
 - `npm run test:full:archive` runs the full suite and stores the current `results.xml` and `test-results.json` under `artifacts/history/<timestamp>/`
 - `npm run archive:reports` archives the current root-level Playwright reports without starting a new test run
+- `npm run check:report-tools` verifies that the report helper modules can be imported without accidental top-level execution
 - `npm run parse:failures` scans `artifacts/history/` recursively and builds a grouped Markdown summary
 - `npm run parse:failures:dir -- <directory>` lets you analyze a different folder, for example a local collection of CI artifacts
 

--- a/scripts/archive-playwright-reports.ts
+++ b/scripts/archive-playwright-reports.ts
@@ -75,8 +75,20 @@ function padNumber(value: number): string {
   return String(value).padStart(2, '0');
 }
 
-void main().catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(message);
-  process.exit(1);
-});
+if (isDirectExecution()) {
+  void main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
+  });
+}
+
+function isDirectExecution(): boolean {
+  const executedPath = process.argv[1];
+
+  if (!executedPath) {
+    return false;
+  }
+
+  return path.resolve(executedPath) === path.resolve(__filename);
+}

--- a/scripts/check-report-tools.ts
+++ b/scripts/check-report-tools.ts
@@ -1,0 +1,7 @@
+/// <reference types="node" />
+
+import './archive-playwright-reports';
+import './run-playwright-and-archive';
+import './playwright-failure-parser';
+
+console.log('Report tool imports are side-effect safe.');

--- a/scripts/playwright-failure-parser.ts
+++ b/scripts/playwright-failure-parser.ts
@@ -572,7 +572,19 @@ function formatError(error: unknown): string {
   return String(error);
 }
 
-void main().catch((error: unknown) => {
-  console.error(formatError(error));
-  process.exit(1);
-});
+if (isDirectExecution()) {
+  void main().catch((error: unknown) => {
+    console.error(formatError(error));
+    process.exit(1);
+  });
+}
+
+function isDirectExecution(): boolean {
+  const executedPath = process.argv[1];
+
+  if (!executedPath) {
+    return false;
+  }
+
+  return path.resolve(executedPath) === path.resolve(__filename);
+}

--- a/scripts/run-playwright-and-archive.ts
+++ b/scripts/run-playwright-and-archive.ts
@@ -1,11 +1,11 @@
 /// <reference types="node" />
 
 import { spawn } from 'node:child_process';
+import path from 'node:path';
 
 import { archiveReports } from './archive-playwright-reports';
 
-async function main(): Promise<void> {
-  const playwrightArguments = process.argv.slice(2);
+export async function runPlaywrightAndArchive(playwrightArguments: string[]): Promise<number> {
   const exitCode = await runPlaywright(playwrightArguments);
 
   try {
@@ -15,9 +15,16 @@ async function main(): Promise<void> {
     console.error(`Archiving failed: ${message}`);
 
     if (exitCode === 0) {
-      process.exit(1);
+      return 1;
     }
   }
+
+  return exitCode;
+}
+
+async function main(): Promise<void> {
+  const playwrightArguments = process.argv.slice(2);
+  const exitCode = await runPlaywrightAndArchive(playwrightArguments);
 
   process.exit(exitCode);
 }
@@ -43,8 +50,20 @@ function runPlaywright(playwrightArguments: string[]): Promise<number> {
   });
 }
 
-void main().catch((error: unknown) => {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(message);
-  process.exit(1);
-});
+if (isDirectExecution()) {
+  void main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
+  });
+}
+
+function isDirectExecution(): boolean {
+  const executedPath = process.argv[1];
+
+  if (!executedPath) {
+    return false;
+  }
+
+  return path.resolve(executedPath) === path.resolve(__filename);
+}


### PR DESCRIPTION
Follow-up fix for the recently merged Playwright report tooling.

This PR fixes import-time side effects in the report helper scripts that
caused the nightly archive runner to fail before reports were generated.
It also adds a lightweight CI guard to catch similar issues before merge.
