### PR TITLE
Fail list

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -86,6 +86,19 @@ jobs:
             mv results.xml results-changed.xml
           fi
           exit $status
+      - name: Build changed failed tests list
+        if: always()
+        shell: bash
+        run: |
+          if [ -f test-results.json ]; then
+            npm run parse:failed-tests -- test-results.json --output-dir .
+          else
+            {
+              echo "### Failed tests"
+              echo
+              echo "No Playwright JSON report was found."
+            } > failed-tests-summary.md
+          fi
       - name: No changed specs detected
         if: steps.changed.outputs.has-tests != 'true'
         run: echo "No changed spec files found in this diff."
@@ -134,12 +147,24 @@ jobs:
             else
               echo "| changed-tests | 0 | 0 | 0 | 0 | run completed without junit results |"
             fi
+            echo
+            cat failed-tests-summary.md
           } >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && hashFiles('playwright-report/**') != '' }}
         with:
           name: playwright-report-changed-tests
           path: playwright-report/
+          retention-days: 7
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() && !cancelled() }}
+        with:
+          name: playwright-logs-changed-tests
+          path: |
+            results-changed.xml
+            test-results.json
+            failed-tests-summary.*
+            test-results/
           retention-days: 7
 
   smoke:
@@ -186,6 +211,9 @@ jobs:
           if [ -f results.xml ]; then
             mv results.xml results-smoke-api.xml
           fi
+          if [ -f test-results.json ]; then
+            mv test-results.json test-results-smoke-api.json
+          fi
           exit $status
       - name: Run browser smoke tests
         id: smoke-browser
@@ -198,10 +226,26 @@ jobs:
           if [ -f results.xml ]; then
             mv results.xml results-smoke-browser.xml
           fi
+          if [ -f test-results.json ]; then
+            mv test-results.json test-results-smoke-browser.json
+          fi
           exit $status
       - name: Fail smoke job when any smoke segment fails
         if: always() && (steps.smoke-api.outcome != 'success' || steps.smoke-browser.outcome != 'success')
         run: exit 1
+      - name: Build smoke failed tests list
+        if: always()
+        shell: bash
+        run: |
+          if ls test-results-smoke-*.json >/dev/null 2>&1; then
+            npm run parse:failed-tests -- test-results-smoke-*.json --output-dir .
+          else
+            {
+              echo "### Failed tests"
+              echo
+              echo "No Playwright JSON report was found."
+            } > failed-tests-summary.md
+          fi
       - name: Parse smoke test results
         id: smoke-results
         if: always()
@@ -257,12 +301,24 @@ jobs:
             else
               echo "| smoke | 0 | 0 | 0 | 0 | no junit results generated |"
             fi
+            echo
+            cat failed-tests-summary.md
           } >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && hashFiles('playwright-report/**') != '' }}
         with:
           name: playwright-report-smoke
           path: playwright-report/
+          retention-days: 7
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() && !cancelled() }}
+        with:
+          name: playwright-logs-smoke
+          path: |
+            results-smoke-*.xml
+            test-results-smoke-*.json
+            failed-tests-summary.*
+            test-results/
           retention-days: 7
 
   a11y-smoke:
@@ -319,6 +375,19 @@ jobs:
             mv results.xml results-a11y-smoke.xml
           fi
           exit $status
+      - name: Build a11y smoke failed tests list
+        if: always()
+        shell: bash
+        run: |
+          if [ -f test-results.json ]; then
+            npm run parse:failed-tests -- test-results.json --output-dir .
+          else
+            {
+              echo "### Failed tests"
+              echo
+              echo "No Playwright JSON report was found."
+            } > failed-tests-summary.md
+          fi
       - name: Placeholder for a11y smoke tests
         if: steps.a11y.outputs.has-tests != 'true'
         run: echo "No @a11y-smoke tests tagged yet. Job reserved for lightweight accessibility checks."
@@ -367,10 +436,22 @@ jobs:
             else
               echo "| a11y-smoke | 0 | 0 | 0 | 0 | run completed without junit results |"
             fi
+            echo
+            cat failed-tests-summary.md
           } >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && hashFiles('playwright-report/**') != '' }}
         with:
           name: playwright-report-a11y-smoke
           path: playwright-report/
+          retention-days: 7
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() && !cancelled() }}
+        with:
+          name: playwright-logs-a11y-smoke
+          path: |
+            results-a11y-smoke.xml
+            test-results.json
+            failed-tests-summary.*
+            test-results/
           retention-days: 7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,6 +54,33 @@ jobs:
       - name: Build failure summary
         if: always()
         run: npm run parse:failures
+      - name: Build failed tests list
+        id: failed-tests
+        if: always()
+        shell: bash
+        run: |
+          if [ -f test-results.json ]; then
+            npm run parse:failed-tests -- test-results.json --output-dir .
+          else
+            {
+              echo "### Failed tests"
+              echo
+              echo "No Playwright JSON report was found."
+            } > failed-tests-summary.md
+            {
+              echo "<h3>Failed Tests</h3>"
+              echo "<p>No Playwright JSON report was found.</p>"
+            } > failed-tests-summary.html
+            {
+              echo "count=0"
+              echo "markdown<<EOF"
+              cat failed-tests-summary.md
+              echo "EOF"
+              echo "html<<EOF"
+              cat failed-tests-summary.html
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
       - uses: actions/upload-artifact@v4
         if: ${{ always() && !cancelled() && hashFiles('playwright-report/**') != '' }}
         with:
@@ -67,6 +94,7 @@ jobs:
           path: |
             results*.xml
             test-results.json
+            failed-tests-summary.*
             test-results/
             artifacts/history/
           retention-days: 7
@@ -105,6 +133,8 @@ jobs:
             echo "| Job | Tests | Passed | Skipped | Failed | Notes |"
             echo "| --- | ---: | ---: | ---: | ---: | --- |"
             echo "| full-regression | $TOTAL | $PASSED | $SKIPPED | $FAILED | non-a11y regression via npm run test:full:archive |"
+            echo
+            cat failed-tests-summary.md
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Determine mail status
         id: mail-status
@@ -162,6 +192,8 @@ jobs:
               </tr>
             </table>
 
+            ${{ steps.failed-tests.outputs.html }}
+
             <p><b>Run Details:</b> <a href="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}">Click here to see detailed summary</a></p>
             <p><i>Check GitHub Artifacts for full HTML report with screenshots. Artifacts are available for 7 days.</i></p>
 
@@ -206,6 +238,19 @@ jobs:
       - name: Parse a11y failures
         if: always()
         run: npx tsx scripts/playwright-failure-parser.ts .
+      - name: Build a11y failed tests list
+        if: always()
+        shell: bash
+        run: |
+          if [ -f test-results.json ]; then
+            npm run parse:failed-tests -- test-results.json --output-dir .
+          else
+            {
+              echo "### Failed tests"
+              echo
+              echo "No Playwright JSON report was found."
+            } > failed-tests-summary.md
+          fi
       - uses: actions/upload-artifact@v4
         if: ${{ always() && !cancelled() && hashFiles('playwright-report/**') != '' }}
         with:
@@ -219,6 +264,7 @@ jobs:
           path: |
             results-a11y.xml
             test-results.json
+            failed-tests-summary.*
             test-results/
             playwright-failure-summary.md
           retention-days: 7
@@ -257,4 +303,6 @@ jobs:
             echo "| Job | Tests | Passed | Skipped | Failed | Notes |"
             echo "| --- | ---: | ---: | ---: | ---: | --- |"
             echo "| a11y | $TOTAL | $PASSED | $SKIPPED | $FAILED | npx playwright test --project=a11y |"
+            echo
+            cat failed-tests-summary.md
           } >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint:fix": "eslint . --ext .ts,.js --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "parse:failed-tests": "tsx scripts/playwright-failed-tests-summary.ts",
     "parse:failures": "tsx scripts/playwright-failure-parser.ts artifacts/history",
     "parse:failures:dir": "tsx scripts/playwright-failure-parser.ts",
     "test:smoke": "npx playwright test --grep @smoke",

--- a/scripts/playwright-failed-tests-summary.ts
+++ b/scripts/playwright-failed-tests-summary.ts
@@ -1,0 +1,378 @@
+/// <reference types="node" />
+
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+type PlaywrightError = {
+  message?: string;
+};
+
+type PlaywrightResult = {
+  error?: PlaywrightError;
+  errors?: PlaywrightError[];
+  status?: string;
+};
+
+type PlaywrightTest = {
+  expectedStatus?: string;
+  projectName?: string;
+  results?: PlaywrightResult[];
+  status?: string;
+};
+
+type PlaywrightSpec = {
+  line?: number;
+  specs?: PlaywrightSpec[];
+  tests?: PlaywrightTest[];
+  title?: string;
+};
+
+type PlaywrightSuite = {
+  file?: string;
+  specs?: PlaywrightSpec[];
+  suites?: PlaywrightSuite[];
+  title?: string;
+};
+
+type PlaywrightReport = {
+  suites: PlaywrightSuite[];
+};
+
+type FailedTest = {
+  error: string;
+  failedAttempts: number;
+  file: string;
+  line: number | undefined;
+  project: string;
+  title: string;
+};
+
+const DEFAULT_MARKDOWN_OUTPUT_FILE = 'failed-tests-summary.md';
+const DEFAULT_HTML_OUTPUT_FILE = 'failed-tests-summary.html';
+const MAX_ERROR_LENGTH = 140;
+
+async function main(): Promise<void> {
+  const { jsonFilePath, outputDirectoryPath } = parseArguments(process.argv.slice(2));
+  const report = await readPlaywrightReport(jsonFilePath);
+  const failedTests = collectFailedTests(report.suites);
+  const markdown = buildMarkdown(failedTests);
+  const html = buildHtml(failedTests);
+
+  await mkdir(outputDirectoryPath, { recursive: true });
+  await writeFile(
+    path.join(outputDirectoryPath, DEFAULT_MARKDOWN_OUTPUT_FILE),
+    `${markdown}\n`,
+    'utf8',
+  );
+  await writeFile(path.join(outputDirectoryPath, DEFAULT_HTML_OUTPUT_FILE), `${html}\n`, 'utf8');
+  await writeGithubOutputs({ count: String(failedTests.length), html, markdown });
+
+  console.log(`Found ${failedTests.length} failed test(s).`);
+}
+
+function parseArguments(args: string[]): { jsonFilePath: string; outputDirectoryPath: string } {
+  const jsonFilePath = args[0];
+
+  if (!jsonFilePath) {
+    console.error(
+      'Usage: npx tsx scripts/playwright-failed-tests-summary.ts <test-results.json> [--output-dir <directory>]',
+    );
+    process.exit(1);
+  }
+
+  const outputDirectoryIndex = args.indexOf('--output-dir');
+  const outputDirectoryPath =
+    outputDirectoryIndex >= 0 ? args[outputDirectoryIndex + 1] : process.cwd();
+
+  if (!outputDirectoryPath) {
+    console.error('Missing value for --output-dir');
+    process.exit(1);
+  }
+
+  return {
+    jsonFilePath: path.resolve(jsonFilePath),
+    outputDirectoryPath: path.resolve(outputDirectoryPath),
+  };
+}
+
+async function readPlaywrightReport(jsonFilePath: string): Promise<PlaywrightReport> {
+  const content = await readFile(jsonFilePath, 'utf8');
+  const parsed = JSON.parse(content) as unknown;
+
+  if (!isPlaywrightReport(parsed)) {
+    throw new Error(`File is not a Playwright JSON report: ${jsonFilePath}`);
+  }
+
+  return parsed;
+}
+
+function collectFailedTests(suites: PlaywrightSuite[]): FailedTest[] {
+  const failedTests: FailedTest[] = [];
+
+  for (const suite of suites) {
+    failedTests.push(...collectFailedTestsFromSuite(suite, []));
+  }
+
+  return deduplicateFailedTests(failedTests).sort((left, right) => {
+    const byProject = left.project.localeCompare(right.project);
+
+    if (byProject !== 0) {
+      return byProject;
+    }
+
+    return left.title.localeCompare(right.title);
+  });
+}
+
+function collectFailedTestsFromSuite(
+  suite: PlaywrightSuite,
+  ancestorTitles: string[],
+): FailedTest[] {
+  const failedTests: FailedTest[] = [];
+  const nextAncestorTitles = [...ancestorTitles, ...buildSuiteTitleParts(suite.title)];
+
+  for (const spec of suite.specs ?? []) {
+    const title = buildTestTitle(nextAncestorTitles, spec.title);
+
+    if (!title) {
+      continue;
+    }
+
+    for (const test of spec.tests ?? []) {
+      if (!isFinalFailure(test)) {
+        continue;
+      }
+
+      failedTests.push({
+        error: extractLastFailureError(test),
+        failedAttempts: countFailedAttempts(test),
+        file: normalizeFilePath(suite.file),
+        line: spec.line,
+        project: test.projectName?.trim() || 'unknown',
+        title,
+      });
+    }
+  }
+
+  for (const nestedSuite of suite.suites ?? []) {
+    failedTests.push(...collectFailedTestsFromSuite(nestedSuite, nextAncestorTitles));
+  }
+
+  return failedTests;
+}
+
+function buildSuiteTitleParts(suiteTitle: string | undefined): string[] {
+  const trimmedTitle = suiteTitle?.trim();
+
+  if (!trimmedTitle) {
+    return [];
+  }
+
+  if (trimmedTitle.endsWith('.spec.ts') || trimmedTitle.endsWith('.api.spec.ts')) {
+    return [];
+  }
+
+  return [trimmedTitle];
+}
+
+function buildTestTitle(ancestorTitles: string[], specTitle: string | undefined): string {
+  const trimmedSpecTitle = specTitle?.trim();
+
+  if (!trimmedSpecTitle) {
+    return '';
+  }
+
+  return [...ancestorTitles, trimmedSpecTitle].join(' > ');
+}
+
+function isFinalFailure(test: PlaywrightTest): boolean {
+  if (test.expectedStatus && test.expectedStatus !== 'passed') {
+    return false;
+  }
+
+  if (test.status === 'unexpected') {
+    return true;
+  }
+
+  if (test.status && test.status !== 'unexpected') {
+    return false;
+  }
+
+  const lastResult = test.results?.at(-1);
+
+  return lastResult?.status === 'failed' || lastResult?.status === 'timedOut';
+}
+
+function countFailedAttempts(test: PlaywrightTest): number {
+  return (test.results ?? []).filter(
+    (result) => result.status === 'failed' || result.status === 'timedOut',
+  ).length;
+}
+
+function extractLastFailureError(test: PlaywrightTest): string {
+  const failedResults = (test.results ?? []).filter(
+    (result) => result.status === 'failed' || result.status === 'timedOut',
+  );
+  const lastFailedResult = failedResults.at(-1);
+  const messages = [
+    lastFailedResult?.error?.message,
+    ...(lastFailedResult?.errors ?? []).map((error) => error.message),
+  ];
+  const message = messages.map(normalizeErrorMessage).find((value) => value.length > 0);
+
+  return truncateForDisplay(message || 'No failure message in report.', MAX_ERROR_LENGTH);
+}
+
+function normalizeErrorMessage(message: string | undefined): string {
+  return (message ?? '')
+    .replace(new RegExp(String.raw`\u001b\[[0-9;]*m`, 'g'), '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => !/^\[[^\]]+\]\s+>/.test(line))
+    .filter((line) => !/^at\s/.test(line))
+    .filter((line) => !/^\d+\s+\|/.test(line))
+    .filter((line) => !/^>\s*\d+\s+\|/.test(line))
+    .filter((line) => line !== 'Call log:')
+    .slice(0, 2)
+    .join(' ');
+}
+
+function deduplicateFailedTests(failedTests: FailedTest[]): FailedTest[] {
+  const deduplicated = new Map<string, FailedTest>();
+
+  for (const failedTest of failedTests) {
+    const key = `${failedTest.project}|||${failedTest.file}|||${failedTest.line ?? ''}|||${failedTest.title}`;
+    const existing = deduplicated.get(key);
+
+    if (!existing || failedTest.failedAttempts > existing.failedAttempts) {
+      deduplicated.set(key, failedTest);
+    }
+  }
+
+  return [...deduplicated.values()];
+}
+
+function buildMarkdown(failedTests: FailedTest[]): string {
+  if (failedTests.length === 0) {
+    return '### Failed tests\n\nNo failed tests in the final Playwright results.';
+  }
+
+  const lines = [
+    `### Failed tests (${failedTests.length})`,
+    '',
+    '| Project | Test | Location | Failed attempts | Last error |',
+    '| --- | --- | --- | ---: | --- |',
+  ];
+
+  for (const failedTest of failedTests) {
+    lines.push(
+      `| ${escapeMarkdownCell(failedTest.project)} | ${escapeMarkdownCell(failedTest.title)} | ${escapeMarkdownCell(buildLocation(failedTest))} | ${failedTest.failedAttempts} | ${escapeMarkdownCell(failedTest.error)} |`,
+    );
+  }
+
+  return lines.join('\n');
+}
+
+function buildHtml(failedTests: FailedTest[]): string {
+  if (failedTests.length === 0) {
+    return '<h3>Failed Tests</h3><p>No failed tests in the final Playwright results.</p>';
+  }
+
+  const rows = failedTests
+    .map(
+      (failedTest) => `<tr>
+  <td>${escapeHtml(failedTest.project)}</td>
+  <td>${escapeHtml(failedTest.title)}</td>
+  <td><code>${escapeHtml(buildLocation(failedTest))}</code></td>
+  <td style="text-align:center">${failedTest.failedAttempts}</td>
+  <td>${escapeHtml(failedTest.error)}</td>
+</tr>`,
+    )
+    .join('\n');
+
+  return `<h3>Failed Tests (${failedTests.length})</h3>
+<table border="1" cellpadding="8" cellspacing="0" style="border-collapse:collapse">
+  <tr style="background:#f0f0f0">
+    <th>Project</th><th>Test</th><th>Location</th><th>Failed attempts</th><th>Last error</th>
+  </tr>
+${rows}
+</table>`;
+}
+
+function buildLocation(failedTest: FailedTest): string {
+  return failedTest.line ? `${failedTest.file}:${failedTest.line}` : failedTest.file;
+}
+
+function normalizeFilePath(filePath: string | undefined): string {
+  return (filePath || 'unknown').replace(/\\/g, '/');
+}
+
+function truncateForDisplay(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+
+  return `${value.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
+function escapeMarkdownCell(value: string): string {
+  return value.replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>');
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+async function writeGithubOutputs(outputs: Record<string, string>): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT;
+
+  if (!outputPath) {
+    return;
+  }
+
+  const lines: string[] = [];
+
+  for (const [name, value] of Object.entries(outputs)) {
+    const delimiter = `playwright_failed_tests_${name}_${Date.now()}`;
+
+    lines.push(`${name}<<${delimiter}`, value, delimiter);
+  }
+
+  await appendFile(outputPath, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function isPlaywrightReport(value: unknown): value is PlaywrightReport {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return Array.isArray(value.suites);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+if (isDirectExecution()) {
+  void main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
+  });
+}
+
+function isDirectExecution(): boolean {
+  const executedPath = process.argv[1];
+
+  if (!executedPath) {
+    return false;
+  }
+
+  return path.resolve(executedPath) === path.resolve(__filename);
+}

--- a/scripts/playwright-failed-tests-summary.ts
+++ b/scripts/playwright-failed-tests-summary.ts
@@ -52,9 +52,11 @@ const DEFAULT_HTML_OUTPUT_FILE = 'failed-tests-summary.html';
 const MAX_ERROR_LENGTH = 140;
 
 async function main(): Promise<void> {
-  const { jsonFilePath, outputDirectoryPath } = parseArguments(process.argv.slice(2));
-  const report = await readPlaywrightReport(jsonFilePath);
-  const failedTests = collectFailedTests(report.suites);
+  const { jsonFilePaths, outputDirectoryPath } = parseArguments(process.argv.slice(2));
+  const reports = await Promise.all(
+    jsonFilePaths.map((jsonFilePath) => readPlaywrightReport(jsonFilePath)),
+  );
+  const failedTests = collectFailedTests(reports.flatMap((report) => report.suites));
   const markdown = buildMarkdown(failedTests);
   const html = buildHtml(failedTests);
 
@@ -70,17 +72,18 @@ async function main(): Promise<void> {
   console.log(`Found ${failedTests.length} failed test(s).`);
 }
 
-function parseArguments(args: string[]): { jsonFilePath: string; outputDirectoryPath: string } {
-  const jsonFilePath = args[0];
+function parseArguments(args: string[]): { jsonFilePaths: string[]; outputDirectoryPath: string } {
+  const outputDirectoryIndex = args.indexOf('--output-dir');
+  const jsonFilePaths =
+    outputDirectoryIndex >= 0 ? args.slice(0, outputDirectoryIndex) : args.slice(0);
 
-  if (!jsonFilePath) {
+  if (jsonFilePaths.length === 0) {
     console.error(
-      'Usage: npx tsx scripts/playwright-failed-tests-summary.ts <test-results.json> [--output-dir <directory>]',
+      'Usage: npx tsx scripts/playwright-failed-tests-summary.ts <test-results.json...> [--output-dir <directory>]',
     );
     process.exit(1);
   }
 
-  const outputDirectoryIndex = args.indexOf('--output-dir');
   const outputDirectoryPath =
     outputDirectoryIndex >= 0 ? args[outputDirectoryIndex + 1] : process.cwd();
 
@@ -90,7 +93,7 @@ function parseArguments(args: string[]): { jsonFilePath: string; outputDirectory
   }
 
   return {
-    jsonFilePath: path.resolve(jsonFilePath),
+    jsonFilePaths: jsonFilePaths.map((jsonFilePath) => path.resolve(jsonFilePath)),
     outputDirectoryPath: path.resolve(outputDirectoryPath),
   };
 }

--- a/tests/api/chain/order-state.chain.api.spec.ts
+++ b/tests/api/chain/order-state.chain.api.spec.ts
@@ -42,7 +42,7 @@ test.describe('Order State Coverage', () => {
     );
     const invoiceAmount = extractInvoiceAmount(invoiceBody);
 
-    expect(invoiceAmount).toBe(expectedAmount);
+    expect(invoiceAmount).not.toBe(expectedAmount);
 
     testInfo.annotations.push({
       type: 'Finding',

--- a/tests/api/chain/order-state.chain.api.spec.ts
+++ b/tests/api/chain/order-state.chain.api.spec.ts
@@ -42,7 +42,7 @@ test.describe('Order State Coverage', () => {
     );
     const invoiceAmount = extractInvoiceAmount(invoiceBody);
 
-    expect(invoiceAmount).not.toBe(expectedAmount);
+    expect(invoiceAmount).toBe(expectedAmount);
 
     testInfo.annotations.push({
       type: 'Finding',


### PR DESCRIPTION
## Summary

Adds a dedicated failed tests list to CI and nightly reporting so real final failures are easy to identify without digging through GitHub annotations and retry noise.

## Changes

- Added `scripts/playwright-failed-tests-summary.ts` to parse Playwright JSON reports and generate:
  - `failed-tests-summary.md` for GitHub job summaries
  - `failed-tests-summary.html` for nightly email
- Added `npm run parse:failed-tests`
- Updated `nightly.yml` to include the failed tests table in:
  - full-regression GitHub Summary
  - nightly email body
  - uploaded logs artifacts
- Updated `ci-pr.yml` to include the failed tests table for:
  - changed-tests
  - smoke
  - a11y-smoke
- Preserved separate smoke JSON reports so API and browser smoke results are both included.

## Notes

The parser reports only final unexpected Playwright failures and ignores expected failures, so retries and known expected failures do not duplicate or pollute the list.

## Validation

- Verified nightly email and GitHub Summary render the failed tests table correctly.
- Tested parser with single and multiple Playwright JSON reports.
- Ran Prettier, ESLint, and TypeScript checks for the new parser.
